### PR TITLE
Fix Async Tasks

### DIFF
--- a/src/main/java/me/itsmas/forgemodblocker/ForgeModBlocker.java
+++ b/src/main/java/me/itsmas/forgemodblocker/ForgeModBlocker.java
@@ -7,6 +7,7 @@ import me.itsmas.forgemodblocker.update.Updater;
 import me.itsmas.forgemodblocker.util.C;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
 /**
  * Main class for the ForgeModBlocker plugin
@@ -37,6 +38,20 @@ public class ForgeModBlocker extends JavaPlugin
         new Updater(this);
 
         modManager = new ModManager(this);
+    }
+
+    @Override
+    public void onDisable()
+    {
+        destroyTasks();
+    }
+
+    /**
+     * Cancels all ongoing plugin tasks
+     */
+    private void destroyTasks()
+    {
+        Bukkit.getScheduler().getPendingTasks().stream().filter(task -> task.getOwner() == this).forEach(BukkitTask::cancel);
     }
 
     /**

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ForgeModBlocker
-version: 1.2.5
+version: 1.2.6
 
 author: Mas281
 authors: [Mas281, Okx]


### PR DESCRIPTION
Plugin will properly cleanup all async tasks, meaning spiget.org will no longer get spammed with my requests...